### PR TITLE
Table was showing as an HTML content

### DIFF
--- a/ch05/5.3/5.3.md
+++ b/ch05/5.3/5.3.md
@@ -14,37 +14,37 @@
 
 1. 
 
-    <table>
-        <thead>
-            <tr>
-                <th></th>
-                <th>产生式</th>
-                <th>语法规则</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>1)</td>
-                <td>E -> E_1 + T</td>
-                <td>E.type = E_1.type === float || T.type === float ? float : int</td>
-            </tr>
-            <tr>
-                <td>2)</td>
-                <td>E -> T</td>
-                <td>E.type = T.type</td>
-            </tr>
-            <tr>
-                <td>3)</td>
-                <td>T -> num.num</td>
-                <td>T.type = float</td>
-            </tr>
-            <tr>
-                <td>4)</td>
-                <td>T -> num</td>
-                <td>T.type = int</td>
-            </tr>
-        </tbody>
-    </table>
+<table>
+    <thead>
+        <tr>
+            <th></th>
+            <th>产生式</th>
+            <th>语法规则</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1)</td>
+            <td>E -> E_1 + T</td>
+            <td>E.type = E_1.type === float || T.type === float ? float : int</td>
+        </tr>
+        <tr>
+            <td>2)</td>
+            <td>E -> T</td>
+            <td>E.type = T.type</td>
+        </tr>
+        <tr>
+            <td>3)</td>
+            <td>T -> num.num</td>
+            <td>T.type = float</td>
+        </tr>
+        <tr>
+            <td>4)</td>
+            <td>T -> num</td>
+            <td>T.type = int</td>
+        </tr>
+    </tbody>
+</table>
 
 
 ### 5.3.2 !


### PR DESCRIPTION
The table of 5.3.1 -> 1 had a tab which resulted in the readme to show it as a code instead of translating it to a table. I have removed the tab here.